### PR TITLE
Simplified code

### DIFF
--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -641,9 +641,8 @@ class Image:
         b = io.BytesIO()
         try:
             self.save(b, image_format, **kwargs)
-        except Exception as e:
-            msg = f"Could not save to {image_format} for display"
-            raise ValueError(msg) from e
+        except Exception:
+            return None
         return b.getvalue()
 
     def _repr_png_(self):
@@ -651,20 +650,14 @@ class Image:
 
         :returns: PNG version of the image as bytes
         """
-        try:
-            return self._repr_image("PNG", compress_level=1)
-        except Exception:
-            return None
+        return self._repr_image("PNG", compress_level=1)
 
     def _repr_jpeg_(self):
         """iPython display hook support for JPEG format.
 
         :returns: JPEG version of the image as bytes
         """
-        try:
-            return self._repr_image("JPEG")
-        except Exception:
-            return None
+        return self._repr_image("JPEG")
 
     @property
     def __array_interface__(self):


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7266

In ` _repr_png_` and `_repr_jpeg_`, you're catching all exceptions from our custom `_repr_image` method, but if you look at `_repr_image`, it seems clear that all exceptions raised when saving are already caught there.

So this suggestion just returns `None` from `_repr_image` directly.